### PR TITLE
Add name_identifier import_one task

### DIFF
--- a/lib/tasks/name_identifier.rake
+++ b/lib/tasks/name_identifier.rake
@@ -16,4 +16,14 @@ namespace :name_identifier do
     response = NameIdentifier.import(from_date: from_date, until_date: until_date)
     puts "Queued import for #{response} DOIs created from #{from_date} - #{until_date}."
   end
+
+  task :import_one => :environment do
+    if ENV["DOI"].nil?
+      puts "ENV['DOI'] is required."
+      exit
+    end
+
+    response = NameIdentifier.import_one(doi: ENV['DOI'])
+    puts "Import for #{response} DOI #{ENV['DOI']}"
+  end
 end


### PR DESCRIPTION
Add new rake task and corrosepending model task for name_identifiers.

## Purpose
This is to aid in debugging when DOIs have not been added to profiles.


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
