### PR TITLE
Use profiles admin token in user creation

### DIFF
--- a/app/models/base.rb
+++ b/app/models/base.rb
@@ -391,7 +391,7 @@ class Base
     response = Maremma.put(url, accept: "application/vnd.api+json",
                                 content_type: "application/vnd.api+json",
                                 data: data.to_json,
-                                bearer: ENV["STAFF_ADMIN_TOKEN"])
+                                bearer: ENV["STAFF_PROFILES_ADMIN_TOKEN"])
 
     if [200, 201].include?(response.status)
       Rails.logger.info "[Event Data] User #{orcid} created in Profiles service."


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
Following up from https://github.com/datacite/levriero/commit/2ee23e3ed044c3e08ab012133b0eeeb07d5a49d8 which added the separate JWT for the profiles service, this PR makes it used in the other connection to profiles as currently it is using STAFF_ADMIN token, which has the `uid` value expected by Lupo, rather than the ORCID as expected by Volpino.

This should resolve the 401 Bad Credentials errors currently occurring when Levriero attempts to create a new user in the Profiles service (see https://app.datadoghq.com/logs?query=%22event%20data%22%20%22user%22&cols=host%2Cservice&index=%2A&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1674662400000&to_ts=1674691200000&live=false)


## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
