### PR TITLE
Change check for compressed reports to look through all exception codes

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -89,17 +89,14 @@ class Report < Base
   end
 
   def compressed_report?
-    # puts @data.dig("report","report-header","exceptions")
     return nil if @data.dig("report", "report-header",
                             "exceptions").blank?
     return nil unless @data.dig("report", "report-header", "exceptions").any?
 
-    # @data.dig("report","report-header","exceptions").include?(COMPRESSED_HASH_MESSAGE)
     exceptions = @data.dig("report", "report-header", "exceptions")
-    code = exceptions.first.fetch("code", "")
-    if code == 69
-      true
-    end
+    codes = exceptions.map { |exception| exception.fetch("code", "") }
+
+    codes.include?(69)
   end
 
   # def correct_checksum?


### PR DESCRIPTION
Looking at first exception code doesn't always work if there are multiple exception codes, order is variable.

## Purpose
Prevents certain compressed usage reports from being processed.

Related to: https://github.com/datacite/datacite/issues/2200


## Approach
Fixes it

#### Open Questions and Pre-Merge TODOs
N/A
## Learning
N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
