### PR TITLE
move levriero usage into it's own shoryuken group

### DIFF
--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -6,8 +6,12 @@ queues:
   - levriero
 
 groups:
+  levriero_usage:
+    concurrency: 10
+    queues:
+      - levriero_usage
   usage:
     concurrency: 4
     queues:
       - usage
-      - levriero_usage
+      # - levriero_usage


### PR DESCRIPTION
## Purpose
Update the number of threads on each instance consuming messages from levriero usage. If this does not help enough let's try adding levriero_usage to the global shoryuken scope.

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
