### PR TITLE
Increase pool size for memcache connections

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
   # config.action_controller.perform_caching = true
   config.perform_caching = true
   config.action_controller.perform_caching = true
-  config.cache_store = :mem_cache_store, ENV["MEMCACHE_SERVERS"], { namespace: ENV["APPLICATION"] }
+  config.cache_store = :mem_cache_store, ENV["MEMCACHE_SERVERS"], { namespace: ENV["APPLICATION"], pool: { size: 32, timeout: 60}  }
 
   # Don't care if the mailer can't send.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
   config.consider_all_requests_local = false
   config.perform_caching = true
   config.action_controller.perform_caching = true
-  config.cache_store = :mem_cache_store, ENV["MEMCACHE_SERVERS"], { namespace: ENV["APPLICATION"] }
+  config.cache_store = :mem_cache_store, ENV["MEMCACHE_SERVERS"], { namespace: ENV["APPLICATION"], pool: { size: 32, timeout: 60} }
 
   # Attempt to read encrypted secrets from `config/secrets.yml.enc`.
   # Requires an encryption key in `ENV["RAILS_MASTER_KEY"]` or

--- a/config/environments/stage.rb
+++ b/config/environments/stage.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
   # Disable/enable fragment and page caching in ActionController
   config.perform_caching = true
   config.action_controller.perform_caching = true
-  config.cache_store = :mem_cache_store, ENV["MEMCACHE_SERVERS"], { namespace: ENV["APPLICATION"] }
+  config.cache_store = :mem_cache_store, ENV["MEMCACHE_SERVERS"], { namespace: ENV["APPLICATION"], pool: { size: 32, timeout: 60} }
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
The concurrency of the various event workers is significantly higher than the available pool for memcache connections (because we just use the default, which is 5 connections, and a 5s timeout), and this causes errors when a lot of cache retrievals need to be done at once.

This PR bumps the connection pool in all environments to ensure queued tasks can complete successfully

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
