### PR TITLE
Skip should detect relationType of relatedIdentifier, not relatedIdentifierType

### DIFF
--- a/app/models/name_identifier.rb
+++ b/app/models/name_identifier.rb
@@ -72,8 +72,7 @@ class NameIdentifier < Base
     related_identifiers = Array.wrap(attributes.fetch("relatedIdentifiers",
                                                       nil))
     skip_doi = related_identifiers.any? do |related_identifier|
-      ["IsIdenticalTo", "IsPartOf", "IsPreviousVersionOf",
-       "IsVersionOf"].include?(related_identifier["relatedIdentifierType"])
+      ["IsIdenticalTo", "IsPartOf", "IsPreviousVersionOf", "IsVersionOf"].include?(related_identifier.dig("relationType", ""))
     end
     creators = attributes.fetch("creators", []).select do |n|
       Array.wrap(n.fetch("nameIdentifiers", nil)).any? do |n|

--- a/app/models/name_identifier.rb
+++ b/app/models/name_identifier.rb
@@ -72,7 +72,7 @@ class NameIdentifier < Base
     related_identifiers = Array.wrap(attributes.fetch("relatedIdentifiers",
                                                       nil))
     skip_doi = related_identifiers.any? do |related_identifier|
-      ["IsIdenticalTo", "IsPartOf", "IsPreviousVersionOf", "IsVersionOf"].include?(related_identifier.dig("relationType", ""))
+      ["IsIdenticalTo", "IsPartOf", "IsPreviousVersionOf", "IsVersionOf"].include?(related_identifier["relationType"] || "")
     end
     creators = attributes.fetch("creators", []).select do |n|
       Array.wrap(n.fetch("nameIdentifiers", nil)).any? do |n|

--- a/spec/models/name_identifier_spec.rb
+++ b/spec/models/name_identifier_spec.rb
@@ -108,7 +108,7 @@ describe NameIdentifier, type: :model, vcr: true do
               "doi" => "https://doi.org/10.0001/foo.bar",
               "updated" => "2023-11-15",
               "relatedIdentifiers" => [
-                { "relatedIdentifierType" => "IsIdenticalTo" },
+                { "relationType" => "IsIdenticalTo" },
               ],
               "creators" => [
                 "nameIdentifiers" => [
@@ -130,7 +130,7 @@ describe NameIdentifier, type: :model, vcr: true do
               "doi" => "https://doi.org/10.0001/foo.bar",
               "updated" => "2023-11-15",
               "relatedIdentifiers" => [
-                { "relatedIdentifierType" => "IsPartOf" },
+                { "relationType" => "IsPartOf" },
               ],
               "creators" => [
                 "nameIdentifiers" => [
@@ -152,7 +152,7 @@ describe NameIdentifier, type: :model, vcr: true do
               "doi" => "https://doi.org/10.0001/foo.bar",
               "updated" => "2023-11-15",
               "relatedIdentifiers" => [
-                { "relatedIdentifierType" => "IsPreviousVersionOf" },
+                { "relationType" => "IsPreviousVersionOf" },
               ],
               "creators" => [
                 "nameIdentifiers" => [
@@ -174,7 +174,7 @@ describe NameIdentifier, type: :model, vcr: true do
               "doi" => "https://doi.org/10.0001/foo.bar",
               "updated" => "2023-11-15",
               "relatedIdentifiers" => [
-                { "relatedIdentifierType" => "IsVersionOf" },
+                { "relationType" => "IsVersionOf" },
               ],
               "creators" => [
                 "nameIdentifiers" => [


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Claims should not be created for DOIs with the following relationTypes: `[“IsIdenticalTo”, “IsPartOf”, “IsPreviousVersionOf”, “IsVersionOf”]` The code previously checked relatedIdentifierType, but relationType is correct: https://datacite-metadata-schema.readthedocs.io/en/4.6/properties/relatedidentifier/#b-relationtype See: https://support.datacite.org/docs/orcid-auto-update-not-working#isversionof

closes: https://github.com/datacite/datacite/issues/2254

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
