### PR TITLE
Add simple exclusion for orcid claiming based on prefix

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -44,6 +44,7 @@ ENV["CROSSREF_QUERY_URL"] ||= "https://api.eventdata.crossref.org"
 ENV["TRUSTED_IP"] ||= "10.0.40.1"
 ENV["SLACK_WEBHOOK_URL"] ||= ""
 ENV["USER_AGENT"] ||= "Mozilla/5.0 (compatible; Maremma/#{Maremma::VERSION}; mailto:info@datacite.org)"
+ENV["EXCLUDE_PREFIXES_FROM_ORCID_CLAIMING"] ||= ""
 
 module Levriero
   class Application < Rails::Application

--- a/spec/models/name_identifier_spec.rb
+++ b/spec/models/name_identifier_spec.rb
@@ -74,6 +74,11 @@ describe NameIdentifier, type: :model, vcr: true do
             with("VOLPINO_URL").
             and_return("https://fake.volpino.com"))
 
+        allow(ENV).
+          to(receive(:[]).
+            with("EXCLUDE_PREFIXES_FROM_ORCID_CLAIMING").
+            and_return(""))
+
         allow(Base).
           to(receive(:cached_datacite_response).
           and_return("foo" => "bar"))


### PR DESCRIPTION
## Purpose
Adds in simple env for excluding running the orcid claims  based on prefix
Needed to temporarily disable certain prefixes that can potentially overload profiles service.

## Approach
1. Add env var
2. Add condition

#### Open Questions and Pre-Merge TODOs
N/A

## Learning
N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
