### PR TITLE
Remove env specific log level

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,11 +49,6 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
 
-  # "info" includes generic and useful information about system operation, but avoids logging too much
-  # information to avoid inadvertent exposure of personally identifiable information (PII). If you
-  # want to log everything, set the level to "debug".
-  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
-
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -49,5 +49,4 @@ Rails.application.configure do
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
 
-  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "warn")
 end


### PR DESCRIPTION
Log level is controlled by ENV variable, environment specific is not required and prevents easy configuration.

## Purpose
So we can configure via ENV variable.

closes: https://github.com/datacite/product-backlog/issues/739

## Approach
Let the log be specified via the LOG_LEVEL env

#### Open Questions and Pre-Merge TODOs
N/A

## Learning
N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
